### PR TITLE
Implement minor registration with parent consent system

### DIFF
--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -3,11 +3,16 @@
 namespace App\Http\Controllers;
 
 use App\Models\User;
+use App\Models\AgeVerificationLog;
+use App\Models\ParentConsent;
 use App\Services\ActivityLogger;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Validation\ValidationException;
+use Carbon\Carbon;
 
 class AuthController extends Controller
 {
@@ -191,5 +196,191 @@ class AuthController extends Controller
                 'next_step' => 'Waiting for admin approval',
             ],
         ], 201);
+    }
+    
+    /**
+     * Check if a user is a minor based on birth date
+     * CRITICAL: Age calculation must be done on server for legal validity
+     */
+    public function checkAge(Request $request)
+    {
+        $request->validate([
+            'birth_date' => 'required|date|before:today'
+        ]);
+        
+        $birthDate = Carbon::parse($request->birth_date);
+        $serverDate = Carbon::now();
+        $age = $birthDate->age;
+        $isMinor = $age < 18;
+        
+        // Log age verification for audit trail
+        AgeVerificationLog::create([
+            'birth_date' => $birthDate->toDateString(),
+            'calculated_age' => $age,
+            'is_minor' => $isMinor,
+            'server_date' => $serverDate->toDateString(),
+            'ip_address' => $request->ip(),
+            'user_agent' => $request->userAgent()
+        ]);
+        
+        Log::info('Age verification performed', [
+            'birth_date' => $birthDate->toDateString(),
+            'calculated_age' => $age,
+            'is_minor' => $isMinor,
+            'ip' => $request->ip()
+        ]);
+        
+        return response()->json([
+            'is_minor' => $isMinor,
+            'age' => $age,
+            'server_date' => $serverDate->toDateString()
+        ]);
+    }
+    
+    /**
+     * Enhanced registration with parent consent support
+     */
+    public function registerWithConsent(Request $request)
+    {
+        // Basic validation
+        $rules = [
+            'firstName' => 'required|string|max:255',
+            'lastName' => 'required|string|max:255',
+            'email' => 'required|email|unique:users,email',
+            'password' => 'required|string|min:8',
+            'birthDate' => 'required|date|before:today',
+            'gender' => 'nullable|string|in:male,female,other',
+            'phone' => 'nullable|string|max:20',
+            'signature' => 'required|string',
+            'signedAt' => 'required|date',
+            'documentType' => 'required|string',
+            'documentVersion' => 'required|string',
+            'medicalHistory' => 'nullable|array'
+        ];
+        
+        // Check if user is minor
+        $birthDate = Carbon::parse($request->birthDate);
+        $age = $birthDate->age;
+        $isMinor = $age < 18;
+        
+        // Add parent consent validation if minor
+        if ($isMinor && $request->has('parentConsent')) {
+            $rules['parentConsent'] = 'required|array';
+            $rules['parentConsent.parentFullName'] = 'required|string|max:255';
+            $rules['parentConsent.fatherFirstName'] = 'required|string|max:100';
+            $rules['parentConsent.fatherLastName'] = 'required|string|max:100';
+            $rules['parentConsent.motherFirstName'] = 'required|string|max:100';
+            $rules['parentConsent.motherLastName'] = 'required|string|max:100';
+            $rules['parentConsent.parentBirthDate'] = 'required|date|before:' . now()->subYears(18)->toDateString();
+            $rules['parentConsent.parentIdNumber'] = 'required|string|max:20|unique:parent_consents,parent_id_number';
+            $rules['parentConsent.parentPhone'] = 'required|string|max:20';
+            $rules['parentConsent.parentLocation'] = 'required|string|max:100';
+            $rules['parentConsent.parentStreet'] = 'required|string|max:255';
+            $rules['parentConsent.parentStreetNumber'] = 'required|string|max:20';
+            $rules['parentConsent.parentPostalCode'] = 'required|string|size:5';
+            $rules['parentConsent.parentEmail'] = 'required|email|max:255';
+            $rules['parentConsent.consentAccepted'] = 'required|boolean|accepted';
+            $rules['parentConsent.signature'] = 'required|string';
+        }
+        
+        $validated = $request->validate($rules);
+        
+        DB::beginTransaction();
+        try {
+            // Create user
+            $user = User::create([
+                'name' => $validated['firstName'] . ' ' . $validated['lastName'],
+                'email' => $validated['email'],
+                'password' => Hash::make($validated['password']),
+                'phone' => $validated['phone'] ?? null,
+                'date_of_birth' => $birthDate,
+                'is_minor' => $isMinor,
+                'age_at_registration' => $age,
+                'membership_type' => 'Basic',
+                'role' => 'member',
+                'join_date' => now(),
+                'status' => 'pending_approval',
+                'registration_status' => 'pending_approval',
+                'remaining_sessions' => 0,
+                'total_sessions' => 0,
+                'medical_history' => isset($validated['medicalHistory']) ? json_encode($validated['medicalHistory']) : null
+            ]);
+            
+            // Create parent consent if minor
+            if ($isMinor && isset($validated['parentConsent'])) {
+                $parentConsent = $validated['parentConsent'];
+                
+                ParentConsent::create([
+                    'user_id' => $user->id,
+                    'parent_full_name' => $parentConsent['parentFullName'],
+                    'father_first_name' => $parentConsent['fatherFirstName'],
+                    'father_last_name' => $parentConsent['fatherLastName'],
+                    'mother_first_name' => $parentConsent['motherFirstName'],
+                    'mother_last_name' => $parentConsent['motherLastName'],
+                    'parent_birth_date' => $parentConsent['parentBirthDate'],
+                    'parent_id_number' => $parentConsent['parentIdNumber'],
+                    'parent_phone' => $parentConsent['parentPhone'],
+                    'parent_location' => $parentConsent['parentLocation'],
+                    'parent_street' => $parentConsent['parentStreet'],
+                    'parent_street_number' => $parentConsent['parentStreetNumber'],
+                    'parent_postal_code' => $parentConsent['parentPostalCode'],
+                    'parent_email' => $parentConsent['parentEmail'],
+                    'consent_accepted' => true,
+                    'signature' => $parentConsent['signature'],
+                    'consent_text' => 'Parent consent for minor registration',
+                    'consent_version' => '1.0',
+                    'server_timestamp' => now()
+                ]);
+                
+                Log::info('Minor registration with parent consent', [
+                    'user_id' => $user->id,
+                    'age' => $age,
+                    'parent_id' => $parentConsent['parentIdNumber']
+                ]);
+            }
+            
+            // Create signature record
+            $user->signatures()->create([
+                'signature_data' => $validated['signature'],
+                'signed_at' => $validated['signedAt'],
+                'document_type' => $validated['documentType'],
+                'document_version' => $validated['documentVersion'],
+                'ip_address' => $request->ip()
+            ]);
+            
+            DB::commit();
+            
+            // Log the registration
+            ActivityLogger::logRegistration($user);
+            
+            return response()->json([
+                'success' => true,
+                'message' => $isMinor 
+                    ? 'Η εγγραφή του ανηλίκου υποβλήθηκε επιτυχώς με γονική συγκατάθεση. Περιμένετε την έγκριση από τον διαχειριστή.'
+                    : 'Η εγγραφή σας υποβλήθηκε επιτυχώς. Περιμένετε την έγκριση από τον διαχειριστή.',
+                'user' => [
+                    'id' => $user->id,
+                    'name' => $user->name,
+                    'email' => $user->email,
+                    'is_minor' => $user->is_minor,
+                    'age_at_registration' => $user->age_at_registration,
+                    'status' => $user->status,
+                    'registration_status' => $user->registration_status
+                ]
+            ], 201);
+            
+        } catch (\Exception $e) {
+            DB::rollback();
+            Log::error('Registration failed', [
+                'error' => $e->getMessage(),
+                'email' => $request->email
+            ]);
+            
+            return response()->json([
+                'success' => false,
+                'message' => 'Registration failed. Please try again.',
+                'error' => $e->getMessage()
+            ], 500);
+        }
     }
 }

--- a/app/Http/Controllers/MemberController.php
+++ b/app/Http/Controllers/MemberController.php
@@ -13,7 +13,7 @@ class MemberController extends Controller
                     ->orWhereNull('membership_type')
                     ->with(['packages' => function($q) {
                         $q->where('status', 'active');
-                    }]);
+                    }, 'parentConsent']);
         
         if ($request->has('search')) {
             $search = $request->search;

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -52,7 +52,7 @@ class UserController extends Controller
 
     public function show(User $user)
     {
-        return response()->json($user->load('packages', 'bookings', 'activityLogs'));
+        return response()->json($user->load('packages', 'bookings', 'activityLogs', 'parentConsent'));
     }
 
     public function update(Request $request, User $user)

--- a/app/Models/AgeVerificationLog.php
+++ b/app/Models/AgeVerificationLog.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class AgeVerificationLog extends Model
+{
+    use HasFactory;
+
+    public $timestamps = false;
+
+    protected $fillable = [
+        'birth_date',
+        'calculated_age',
+        'is_minor',
+        'server_date',
+        'ip_address',
+        'user_agent'
+    ];
+
+    protected $casts = [
+        'birth_date' => 'date',
+        'server_date' => 'date',
+        'is_minor' => 'boolean',
+        'calculated_age' => 'integer'
+    ];
+}

--- a/app/Models/ParentConsent.php
+++ b/app/Models/ParentConsent.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class ParentConsent extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'user_id',
+        'parent_full_name',
+        'father_first_name',
+        'father_last_name',
+        'mother_first_name',
+        'mother_last_name',
+        'parent_birth_date',
+        'parent_id_number',
+        'parent_phone',
+        'parent_location',
+        'parent_street',
+        'parent_street_number',
+        'parent_postal_code',
+        'parent_email',
+        'consent_accepted',
+        'signature',
+        'consent_text',
+        'consent_version',
+        'server_timestamp'
+    ];
+
+    protected $casts = [
+        'parent_birth_date' => 'date',
+        'consent_accepted' => 'boolean',
+        'server_timestamp' => 'datetime'
+    ];
+
+    /**
+     * Get the user that owns the parent consent.
+     */
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    /**
+     * Get parent's full address
+     */
+    public function getFullAddressAttribute()
+    {
+        return "{$this->parent_street} {$this->parent_street_number}, {$this->parent_postal_code} {$this->parent_location}";
+    }
+
+    /**
+     * Check if parent is adult (over 18)
+     */
+    public function isParentAdult()
+    {
+        return $this->parent_birth_date->age >= 18;
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -24,6 +24,8 @@ class User extends Authenticatable
         'phone',
         'address',
         'date_of_birth',
+        'is_minor',
+        'age_at_registration',
         'membership_type',
         'role',
         'join_date',
@@ -74,6 +76,8 @@ class User extends Authenticatable
             'approved_at' => 'datetime',
             'notification_preferences' => 'array',
             'privacy_settings' => 'array',
+            'is_minor' => 'boolean',
+            'age_at_registration' => 'integer',
         ];
     }
 
@@ -290,5 +294,45 @@ class User extends Authenticatable
     public function hasEnoughLoyaltyPoints($amount)
     {
         return $this->loyalty_points_balance >= $amount;
+    }
+    
+    /**
+     * Parent consent relationship
+     */
+    public function parentConsent()
+    {
+        return $this->hasOne(ParentConsent::class);
+    }
+    
+    /**
+     * Check if user is currently a minor
+     */
+    public function isCurrentlyMinor()
+    {
+        if (!$this->date_of_birth) {
+            return false;
+        }
+        
+        return $this->date_of_birth->age < 18;
+    }
+    
+    /**
+     * Check if user was minor at registration
+     */
+    public function wasMinorAtRegistration()
+    {
+        return $this->is_minor === true;
+    }
+    
+    /**
+     * Get current age
+     */
+    public function getCurrentAge()
+    {
+        if (!$this->date_of_birth) {
+            return null;
+        }
+        
+        return $this->date_of_birth->age;
     }
 }

--- a/database/migrations/2025_08_06_121710_add_minor_fields_to_users_table.php
+++ b/database/migrations/2025_08_06_121710_add_minor_fields_to_users_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->boolean('is_minor')->default(false)->after('date_of_birth');
+            $table->integer('age_at_registration')->nullable()->after('is_minor');
+            $table->index('is_minor');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropIndex(['is_minor']);
+            $table->dropColumn(['is_minor', 'age_at_registration']);
+        });
+    }
+};

--- a/database/migrations/2025_08_06_121716_create_parent_consents_table.php
+++ b/database/migrations/2025_08_06_121716_create_parent_consents_table.php
@@ -1,0 +1,49 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('parent_consents', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->onDelete('cascade');
+            $table->string('parent_full_name');
+            $table->string('father_first_name', 100);
+            $table->string('father_last_name', 100);
+            $table->string('mother_first_name', 100);
+            $table->string('mother_last_name', 100);
+            $table->date('parent_birth_date');
+            $table->string('parent_id_number', 20)->unique();
+            $table->string('parent_phone', 20);
+            $table->string('parent_location', 100);
+            $table->string('parent_street');
+            $table->string('parent_street_number', 20);
+            $table->string('parent_postal_code', 10);
+            $table->string('parent_email');
+            $table->boolean('consent_accepted')->default(true);
+            $table->longText('signature');
+            $table->text('consent_text');
+            $table->string('consent_version', 10)->default('1.0');
+            $table->timestamp('server_timestamp')->useCurrent();
+            $table->timestamps();
+            
+            $table->index('parent_id_number');
+            $table->index('user_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('parent_consents');
+    }
+};

--- a/database/migrations/2025_08_06_121721_create_age_verification_logs_table.php
+++ b/database/migrations/2025_08_06_121721_create_age_verification_logs_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('age_verification_logs', function (Blueprint $table) {
+            $table->id();
+            $table->date('birth_date');
+            $table->integer('calculated_age');
+            $table->boolean('is_minor');
+            $table->date('server_date');
+            $table->string('ip_address', 45)->nullable();
+            $table->text('user_agent')->nullable();
+            $table->timestamp('created_at')->useCurrent();
+            
+            $table->index('created_at');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('age_verification_logs');
+    }
+};

--- a/resources/views/admin/members/index.blade.php
+++ b/resources/views/admin/members/index.blade.php
@@ -41,6 +41,7 @@
                 <tr>
                     <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Member</th>
                     <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Contact</th>
+                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Age</th>
                     <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Membership</th>
                     <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Status</th>
                     <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Joined</th>
@@ -66,6 +67,25 @@
                     <td class="px-6 py-4 whitespace-nowrap">
                         <div class="text-sm text-gray-900">{{ $member->email }}</div>
                         <div class="text-sm text-gray-500">{{ $member->phone ?? 'No phone' }}</div>
+                    </td>
+                    <td class="px-6 py-4 whitespace-nowrap">
+                        @if($member->age_at_registration)
+                            <span class="text-sm font-medium {{ $member->is_minor ? 'text-red-600' : 'text-gray-900' }}">
+                                {{ $member->age_at_registration }} yrs
+                            </span>
+                            @if($member->is_minor)
+                                <div class="flex items-center mt-1">
+                                    <span class="text-xs bg-red-100 text-red-800 px-2 py-1 rounded">Minor</span>
+                                    @if($member->parentConsent)
+                                        <span class="ml-1 text-green-600" title="Parent consent provided">
+                                            <i class="fas fa-check-circle text-xs"></i>
+                                        </span>
+                                    @endif
+                                </div>
+                            @endif
+                        @else
+                            <span class="text-sm text-gray-400">-</span>
+                        @endif
                     </td>
                     <td class="px-6 py-4 whitespace-nowrap">
                         <div class="text-sm text-gray-900">{{ $member->membership_type ?? 'Standard' }}</div>
@@ -314,6 +334,7 @@
                             <div><dt class="text-sm text-gray-500">Email:</dt><dd class="text-sm font-medium">${data.email}</dd></div>
                             <div><dt class="text-sm text-gray-500">Phone:</dt><dd class="text-sm font-medium">${data.phone || 'N/A'}</dd></div>
                             <div><dt class="text-sm text-gray-500">Date of Birth:</dt><dd class="text-sm font-medium">${data.date_of_birth || 'N/A'}</dd></div>
+                            <div><dt class="text-sm text-gray-500">Age at Registration:</dt><dd class="text-sm font-medium">${data.age_at_registration ? data.age_at_registration + ' years' : 'N/A'} ${data.is_minor ? '<span class="text-red-600">(Minor)</span>' : ''}</dd></div>
                             <div><dt class="text-sm text-gray-500">Address:</dt><dd class="text-sm font-medium">${data.address || 'N/A'}</dd></div>
                         </dl>
                     </div>
@@ -341,6 +362,39 @@
                                     <div class="text-sm text-gray-600">Sessions: ${pkg.remaining_sessions}/${pkg.total_sessions}</div>
                                 </div>
                             `).join('')}
+                        </div>
+                    </div>
+                ` : ''}
+                
+                ${data.parent_consent ? `
+                    <div class="mt-6 p-4 bg-yellow-50 rounded-lg">
+                        <h4 class="font-semibold text-gray-700 mb-2">
+                            <i class="fas fa-user-shield text-yellow-600 mr-2"></i>
+                            Parent/Guardian Consent Information
+                        </h4>
+                        <div class="grid grid-cols-2 gap-4">
+                            <div>
+                                <dl class="space-y-2">
+                                    <div><dt class="text-sm text-gray-500">Parent Name:</dt><dd class="text-sm font-medium">${data.parent_consent.parent_full_name}</dd></div>
+                                    <div><dt class="text-sm text-gray-500">Father:</dt><dd class="text-sm">${data.parent_consent.father_first_name} ${data.parent_consent.father_last_name}</dd></div>
+                                    <div><dt class="text-sm text-gray-500">Mother:</dt><dd class="text-sm">${data.parent_consent.mother_first_name} ${data.parent_consent.mother_last_name}</dd></div>
+                                    <div><dt class="text-sm text-gray-500">Parent Birth Date:</dt><dd class="text-sm">${data.parent_consent.parent_birth_date}</dd></div>
+                                    <div><dt class="text-sm text-gray-500">ID Number:</dt><dd class="text-sm font-medium">${data.parent_consent.parent_id_number}</dd></div>
+                                </dl>
+                            </div>
+                            <div>
+                                <dl class="space-y-2">
+                                    <div><dt class="text-sm text-gray-500">Phone:</dt><dd class="text-sm font-medium">${data.parent_consent.parent_phone}</dd></div>
+                                    <div><dt class="text-sm text-gray-500">Email:</dt><dd class="text-sm">${data.parent_consent.parent_email}</dd></div>
+                                    <div><dt class="text-sm text-gray-500">Address:</dt><dd class="text-sm">${data.parent_consent.parent_street} ${data.parent_consent.parent_street_number}, ${data.parent_consent.parent_postal_code} ${data.parent_consent.parent_location}</dd></div>
+                                    <div><dt class="text-sm text-gray-500">Consent Date:</dt><dd class="text-sm font-medium">${new Date(data.parent_consent.server_timestamp).toLocaleString()}</dd></div>
+                                    <div>
+                                        <button onclick="viewParentSignature('${data.parent_consent.signature}')" class="text-blue-600 hover:text-blue-800 text-sm">
+                                            <i class="fas fa-signature mr-1"></i>View Signature
+                                        </button>
+                                    </div>
+                                </dl>
+                            </div>
                         </div>
                     </div>
                 ` : ''}
@@ -388,6 +442,41 @@
     // Create Member (placeholder)
     function openCreateModal() {
         alert('Create member functionality will be implemented next');
+    }
+    
+    // View Parent Signature
+    function viewParentSignature(signatureData) {
+        const modal = document.createElement('div');
+        modal.className = 'fixed inset-0 bg-gray-600 bg-opacity-50 overflow-y-auto h-full w-full z-50';
+        modal.innerHTML = `
+            <div class="relative top-20 mx-auto p-5 border w-96 shadow-lg rounded-md bg-white">
+                <div class="mt-3">
+                    <h3 class="text-lg font-medium text-gray-900 mb-4">Parent/Guardian Signature</h3>
+                    <div class="border p-4 bg-gray-50 rounded">
+                        <img src="${signatureData}" alt="Parent Signature" class="w-full h-auto" />
+                    </div>
+                    <div class="mt-4 flex justify-between">
+                        <button onclick="downloadSignature('${signatureData}')" class="px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600">
+                            <i class="fas fa-download mr-2"></i>Download
+                        </button>
+                        <button onclick="this.closest('.fixed').remove()" class="px-4 py-2 bg-gray-500 text-white rounded hover:bg-gray-600">
+                            Close
+                        </button>
+                    </div>
+                </div>
+            </div>
+        `;
+        document.body.appendChild(modal);
+    }
+    
+    // Download Signature
+    function downloadSignature(signatureData) {
+        const link = document.createElement('a');
+        link.href = signatureData;
+        link.download = 'parent_signature.png';
+        document.body.appendChild(link);
+        link.click();
+        document.body.removeChild(link);
     }
 </script>
 @endsection

--- a/routes/api.php
+++ b/routes/api.php
@@ -58,6 +58,8 @@ Route::prefix('admin')->middleware(['auth:sanctum', 'admin'])->group(function ()
 Route::prefix('v1/auth')->group(function () {
     Route::post('/login', [AuthController::class, 'login']);
     Route::post('/register', [AuthController::class, 'register']);
+    Route::post('/register-with-consent', [AuthController::class, 'registerWithConsent']);
+    Route::post('/check-age', [AuthController::class, 'checkAge']);
     Route::post('/logout', [AuthController::class, 'logout'])->middleware('auth:sanctum');
     Route::get('/me', [AuthController::class, 'me'])->middleware('auth:sanctum');
     


### PR DESCRIPTION
Implemented comprehensive support for minor (under 18) registration with parent/guardian consent as specified in issue #10:

Database:
- Added is_minor and age_at_registration fields to users table
- Created parent_consents table to store guardian information and signatures
- Created age_verification_logs table for audit trail
- Added proper indexes and foreign key constraints

Backend:
- Created ParentConsent and AgeVerificationLog models with relationships
- Added age verification endpoint (/api/v1/auth/check-age) that calculates age on server
- Enhanced registration endpoint to handle parent consent for minors
- Server-side age calculation ensures legal validity and prevents client manipulation
- Comprehensive validation for parent consent fields including ID number uniqueness

Admin Panel:
- Added Age column showing registration age with visual minor indicator
- Minor users display red "Minor" badge with parent consent status
- Enhanced member details modal with full parent consent section
- Added parent signature viewing and download functionality
- Parent information includes full contact details and consent timestamp

Security & Compliance:
- All age calculations performed on server for legal validity
- Parent consent stored with server timestamp for audit purposes
- Age verification logged with IP and user agent for compliance
- Parent ID number validation prevents duplicate registrations

Closes #10

🤖 Generated with Claude Code